### PR TITLE
chore: update checkout action

### DIFF
--- a/.github/workflows/dns-update.yml
+++ b/.github/workflows/dns-update.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: [self-hosted, ubuntu, pi]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install email
         run: |


### PR DESCRIPTION
node is being deprecated off the old checkout version